### PR TITLE
improve SFSymbol type

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3356,5 +3356,4 @@ export type SFSymbolName =
    */
   | 'xserve'
 
-type LoseAutoComplete<T extends string> = T | Omit<string, T>
-export type SFSymbol = LoseAutoComplete<SFSymbolName>
+export type SFSymbol = SFSymbolName | (string & {})

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-export type SFSymbol =
+export type SFSymbolName =
   | '0.circle'
   | '0.circle.fill'
   | '0.square'
@@ -3355,3 +3355,6 @@ export type SFSymbol =
    * @see https://developer.apple.com/design/human-interface-guidelines/foundations/sf-symbols#symbols-for-use-as-is
    */
   | 'xserve'
+
+type LoseAutoComplete<T extends string> = T | Omit<string, T>
+export type SFSymbol = LoseAutoComplete<SFSymbolName>

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,3 +1,4 @@
 import { SFSymbol } from '../dist'
 
 let symbol: SFSymbol = 'xserve'
+let circleSlash: SFSymbol = 'circle.slash'


### PR DESCRIPTION
# Why 
Sometimes you may encounter a type error when setting an icon name that is not of in this SFSymbol type.
Fox example: 
![image](https://user-images.githubusercontent.com/37520667/233481477-5c723011-6fe7-4fc5-b8ea-b25109ef1d96.png)

# How  

Use TypeScript's Omit to support SFSymbol type names that are not available, which can avoid type errors.